### PR TITLE
remove hardcoded match patterns and detect SPC at runtime instead

### DIFF
--- a/fixspc/fixspc.css
+++ b/fixspc/fixspc.css
@@ -1,3 +1,3 @@
-textarea[readonly="readonly"] {
+html[data-spcfixes="enabled"] textarea[readonly="readonly"] {
   resize: vertical;
 }

--- a/fixspc/fixspc.js
+++ b/fixspc/fixspc.js
@@ -1,13 +1,28 @@
-// need to bind to some change event since everything is javascript in SPC
-// so we're listening to a change on the content div
-document.getElementById('content').addEventListener('DOMNodeInserted', function () {
-  // find all readonly textareas
-  var readonlyTextareas = document.querySelectorAll("textarea[readonly=readonly]")
-  for (var i = 0; i < readonlyTextareas.length; i++) {
-    // set readonly textarea height to content height
-    var element = readonlyTextareas[i];
-    element.style.height = "5px";
-    element.style.height = (element.scrollHeight+20)+"px";
-  }
+//This is a quite broad match (it matches all SAP UI5 apps), but I could not
+//find anything in the DOM that's specific to SPC (except for a <title> which
+//is only set too late, and the app logo which is an <img> without even an
+//"alt" attribute).
+//
+//TODO: If this broad match causes problems for users who want to use other SAP
+//UI5 apps as well, we might use a MutationObserver to observe the document
+//title, and enable our fixes once we see a title that .endsWith("SAP Service
+//Provider Cockpit") -- see https://stackoverflow.com/a/29540461/334761 for details
+if (document.querySelectorAll("body.sapBUiShellBackground").length > 0) {
+  // enable our custom CSS rules (we do this with a data attribute instead of
+  // a CSS class since SAP UI5 likes to steamroll over the classList regularly)
+  document.getElementsByTagName("html")[0].setAttribute("data-spcfixes", "enabled");
 
-}, false);
+  // need to bind to some change event since everything is javascript in SPC
+  // so we're listening to a change on the content div
+  document.getElementById('content').addEventListener('DOMNodeInserted', function () {
+    // find all readonly textareas
+    var readonlyTextareas = document.querySelectorAll("textarea[readonly=readonly]")
+    for (var i = 0; i < readonlyTextareas.length; i++) {
+      // set readonly textarea height to content height
+      var element = readonlyTextareas[i];
+      element.style.height = "5px";
+      element.style.height = (element.scrollHeight+20)+"px";
+    }
+
+  }, false);
+}

--- a/fixspc/manifest.json
+++ b/fixspc/manifest.json
@@ -6,7 +6,7 @@
   "version": "1.0.1",
   "content_scripts": [
     {
-      "matches": ["https://spc.ondemand.com/*", "https://spc40-emea.byd.sap.corp/*"],
+      "matches": ["<all_urls>"],
       "css": ["fixspc.css"],
       "js": ["fixspc.js"]
     }

--- a/fixspc/manifest.json
+++ b/fixspc/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Fix SPC",
   "description": "This extension makes SPC a bit more usable by resizing the text areas properly according to their content.",
-  "version": "1.0.1",
+  "version": "2.0",
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
This induces a marginal overhead everytime a site is opened, but makes the extension general enough that I can push it to addons.mozilla.org (which is required for Firefox since the normal Firefox, unlike the Developer Edition, won't allow addons not signed by Mozilla to be installed permanently).

Tip: View the diff with [`?w=1`](https://github.com/edda/spcfixes/pull/2/files?w=1).